### PR TITLE
Handle running event loop in LiteLLM prompt handler

### DIFF
--- a/litellmnodes.py
+++ b/litellmnodes.py
@@ -1800,6 +1800,21 @@ class LiteLLMCompletionListOfPrompts:
 
 
         if run_async:
+            running_loop = None
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+
+            if running_loop and running_loop.is_running():
+                print(
+                    "Warning: Async processing requested while an event loop is already running."
+                    " Falling back to synchronous processing.",
+                    file=sys.stderr,
+                )
+                run_async = False
+
+        if run_async:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             try:


### PR DESCRIPTION
## Summary
- avoid starting a new asyncio loop when one is already running in the LiteLLM prompt handler
- fall back to synchronous processing with a clear warning when nested event loops would be created

## Testing
- python -m compileall litellmnodes.py

------
https://chatgpt.com/codex/tasks/task_e_68d2031a4000832cbf2d452baff33bd8